### PR TITLE
fix(attention): rebase RPA v3 span masks to tile-local coordinates

### DIFF
--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
@@ -487,19 +487,45 @@ def _ragged_paged_attention_kernel_loop(
         if soft_cap is not None:
             s = soft_cap * jnp.tanh(s / soft_cap)
 
+        # The masks below compare a query position against a key position inside
+        # the same tile, so they need the *offset* between the two tiles, never
+        # absolute positions. Absolute positions are also unsafe here: the int16
+        # narrowing just below wraps instead of saturating (Mosaic lowers the
+        # cast to arith.trunci), so anything past 32767 silently corrupts the
+        # mask. Rebasing to the key tile's origin keeps every operand within a
+        # couple of tile widths instead.
+
         # Use int16 for span computations when safe: non-f32 dtype on TPU v6+
         # with causal mask. Custom mask shapes can trigger a Mosaic compiler bug.
         int_ty = jnp.int32
-        if get_dtype_packing(q.dtype) != 1 and tpu_version >= 6 and use_causal_mask:
+        if (
+            get_dtype_packing(q.dtype) != 1
+            and tpu_version >= 6
+            and use_causal_mask
+            and bkv_csz + actual_bq_csz <= jnp.iinfo(jnp.int16).max  # widest span below
+        ):
             int_ty = jnp.int16
-        processed_q_len_int = processed_q_len.astype(int_ty)
-        processed_kv_len_int = processed_kv_len.astype(int_ty)
-        effective_kv_len_int = effective_kv_len.astype(int_ty)
-        q_span = processed_q_len_int + (
-            lax.broadcasted_iota(jnp.int32, s.shape, 0) // num_q_heads_per_kv_head
-        ).astype(int_ty)
-        k_span = processed_kv_len_int + lax.broadcasted_iota(int_ty, s.shape, 1)
-        v_span = processed_kv_len_int + lax.broadcasted_iota(int_ty, v.shape, 0)
+        q_row = (lax.broadcasted_iota(jnp.int32, s.shape, 0) // num_q_heads_per_kv_head).astype(
+            int_ty
+        )
+
+        def rebased_q_span(window):
+            """Query span measured from the key tile's origin, less `window`.
+
+            Every predicate using this is monotone in it, and it is only ever
+            compared against k_span in [0, bkv_csz), so once it leaves
+            [-(actual_bq_csz + 1), bkv_csz + 1] the tile is uniformly masked or
+            uniformly visible. Clamping there is exact, not an approximation.
+            Folding `window` in before the clamp keeps an arbitrarily large
+            sliding window out of int16 as well.
+            """
+            delta = processed_q_len - processed_kv_len - window
+            return jnp.clip(delta, -(actual_bq_csz + 1), bkv_csz + 1).astype(int_ty) + q_row
+
+        q_span = rebased_q_span(0)
+        k_span = lax.broadcasted_iota(int_ty, s.shape, 1)
+        v_span = lax.broadcasted_iota(int_ty, v.shape, 0)
+        kv_span_limit = jnp.clip(effective_kv_len - processed_kv_len, 0, bkv_csz).astype(int_ty)
 
         mask = None
         if use_causal_mask:
@@ -511,11 +537,11 @@ def _ragged_paged_attention_kernel_loop(
             mask = mask_and(mask, custom_mask_expanded == 1)
 
         if not skip_kv_mask:
-            mask = mask_and(mask, k_span < effective_kv_len_int)
-            v = jnp.where(v_span < effective_kv_len_int, v, 0.0)
+            mask = mask_and(mask, k_span < kv_span_limit)
+            v = jnp.where(v_span < kv_span_limit, v, 0.0)
 
         if sliding_window is not None:
-            mask = mask_and(mask, q_span < k_span + sliding_window)
+            mask = mask_and(mask, rebased_q_span(sliding_window) < k_span)
 
         if mask is not None:
             s = jnp.where(mask, s, mask_value)

--- a/python/sgl_jax/test/test_flashattention_gqa.py
+++ b/python/sgl_jax/test/test_flashattention_gqa.py
@@ -52,6 +52,55 @@ class TestFlashAttentionGQA(AttentionTestBase):
         ]
         self.run_test("prefill", lens, (num_heads, head_dim, num_kv_heads, 64, jnp.bfloat16))
 
+    def test_gqa_prefill_accuracy_beyond_int16_span(self):
+        """Absolute token positions past 32767 must not corrupt the causal mask.
+
+        On TPU v6+ the kernel narrows its span arithmetic to int16
+        (ragged_paged_attention_v3.py). Mosaic lowers that cast to a wrapping
+        truncation rather than a saturation, so an *absolute* position above
+        32767 silently wraps negative and drops -- or zeroes -- part of the
+        attended prefix. Decode is immune because it forces use_causal_mask off.
+
+        Two long sequences straddle the cliff: 32768 lands a tile's
+        effective_kv_len exactly on the int16 floor (whole-tile zero output),
+        and 40960 wraps ordinarily (prefix silently lost). The batch is
+        deliberately skewed -- one long sequence beside several short ones --
+        so that a bound derived from the batch's average pages-per-sequence
+        would not catch it.
+        """
+        num_heads = 4
+        num_kv_heads = 1
+        head_dim = 128
+        lens = [(64, 32768), (64, 40960)] + [(8, 100)] * 6
+        self.run_test_on_single_device(
+            "prefill",
+            lens,
+            (num_heads, head_dim, num_kv_heads, 16, jnp.bfloat16),
+            max_total_token_size=200000,
+        )
+
+    def test_gqa_sliding_window_beyond_int16_span(self):
+        """Sliding window on a sequence whose absolute positions exceed 32767.
+
+        The window predicate reduces to (delta - sliding_window) + i < j, so it
+        rides on the same narrowed span arithmetic as the causal mask. No other
+        test pairs a non-None sliding window with a sequence past the int16
+        cliff; every other flashattention case tops out near 1K tokens. The
+        boundary key tile -- the one straddling the far edge of the window --
+        is where the predicate does real work.
+        """
+        num_heads = 4
+        num_kv_heads = 1
+        head_dim = 128
+        lens = [(128, 40960)] + [(8, 100)] * 3
+        self.run_test_on_single_device(
+            "prefill",
+            lens,
+            (num_heads, head_dim, num_kv_heads, 16, jnp.bfloat16),
+            max_total_token_size=200000,
+            sliding_window=1024,
+        )
+
     def test_gqa_decode_accuracy_page_size_64(self):
         """Test JAX attention accuracy against native fa"""
         # Parameters

--- a/python/sgl_jax/test/test_flashattention_misc.py
+++ b/python/sgl_jax/test/test_flashattention_misc.py
@@ -32,6 +32,32 @@ class TestFlashAttentionMisc(AttentionTestBase):
             logit_cap=logit_cap,
         )
 
+    def test_sliding_window_narrower_than_sequence_prefill_accuracy(self):
+        """A sliding window that cuts, reached through the production metadata path.
+
+        Both sliding-window tests in this file use a 512-token window against
+        sequences of at most 400, so their window predicate is uniformly true
+        across every tile the kernel visits -- they would pass with the
+        sliding-window arm deleted outright. test_rpa_v3_kv_writeback.py does
+        cut its window, but it calls ragged_paged_attention directly with a
+        hand-built page table. This case reaches the kernel through
+        RadixAttention and the FlashAttention backend instead, so page_indices
+        and cu_kv_lens are built by _pad_page_indices the way they are in
+        production. GQA (32 q / 8 kv) also makes the query row index a
+        floor-divide rather than a plain iota.
+        """
+        num_heads = 32
+        num_kv_heads = 8
+        head_dim = 128
+        lens = [(512, 512), (256, 256), (130, 130)]
+
+        self.run_test(
+            "prefill",
+            lens,
+            (num_heads, head_dim, num_kv_heads, 16, jnp.bfloat16),
+            sliding_window=128,
+        )
+
     def test_sliding_window_and_soft_cap_decode_accuracy(self):
         """Test combined sliding window and soft cap attention accuracy in decode mode"""
         # Parameters


### PR DESCRIPTION
Fixes #1541.

## Motivation

### The bug: silent truncation at 32K

Currently, the RPA v3 kernel downcasts absolute sequence positions (`processed_q_len`, `processed_kv_len`) to `int16` when certain trace-time conditions are met. `int16` tops out at 32767. For sequences longer than this, the cast wraps to negative values.

This causes silent, catastrophic attention truncation in prefill/extend phases (Mode 1: drops early history; Mode 2: produces whole-block zero outputs when `effective_kv_len` hits exactly 32768).

### Why upstream's fix (#2756) fails here

Upstream `tpu-inference` fixed this by gating `int16` behind a strict capacity check: `max_kv_len <= jnp.iinfo(jnp.int16).max`.

However, we **cannot simply cherry-pick this** due to a divergence in our page table layouts:

* Upstream uses a 2D `page_indices` layout where `pages_per_seq` is a strict upper bound per sequence.
* `sglang-jax` uses a 1D flat layout, and our `pages_per_seq` is a **bucketed average** across the batch.

In a ragged batch (e.g., one 60K sequence + seven 100-token sequences), the average falls below 32K, bypassing the upstream guard and causing the 60K sequence to overflow anyway. Furthermore, using the total physical capacity as a guard would tie `int16` to **batch size rather than sequence length** — at `page_size=64` it switches off above a batch of 31, even if every request is a single token.

## Modifications

To permanently fix the overflow while **keeping the `int16` fast path for all context lengths**, this PR shifts the mask arithmetic from *absolute* coordinates to *tile-relative* distances.

Attention masking only cares about the distance between $Q$ and $K$, not their absolute sequence IDs. By calculating the macro distance (`delta`) in safe `int32` and clamping it before the `int16` cast, we make the logic mathematically immune to overflow.

1. **Rebased Q span (`rebased_q_span`)**:
Instead of `q_span = absolute_q`, we use `delta = processed_q_len - processed_kv_len`. We then strictly clamp `delta` to `[-(actual_bq_csz + 1), bkv_csz + 1]` in `int32`.
*Why this is exact:* If `delta` exceeds these bounds, the entire tile is either uniformly masked or uniformly visible. Clamping it to the tile's edge is a mathematically exact transformation, not an approximation.

2. **Absorbing `sliding_window`**:
An arbitrarily large `sliding_window` could previously cause the clamp boundary itself to exceed 32767. We fix this by algebraically absorbing `window` into the `delta` subtraction *before* clamping: `delta = absolute_q - absolute_kv - window`. This keeps the clamp bounds strictly tied to tile sizes, which will never overflow `int16` (across all 2107 `TUNED_BLOCK_SIZES_V3` entries the widest possible span is `4128`).

3. **Localizing KV limits**:
`k_span` is now a localized tile column index `[0, bkv_csz)`. We localized the boundary check by calculating `kv_span_limit = clip(effective_kv_len - processed_kv_len, 0, bkv_csz)`. This accurately flags invalid/padding tokens within the specific tile using safe `int16` comparisons.

## Accuracy Tests

The existing flash-attention suite tops out at `kv_len = 1025`, which is precisely why this went unnoticed. The CPU tier is structurally blind as well: `get_tpu_version()` returns `-1` off-TPU, so the `int16` branch is unreachable there.

Three cases are added, all in files already registered in `unit-test-tpu-v6e-1`:

1. **`test_gqa_prefill_accuracy_beyond_int16_span`** — causal attention at `kv_len` 32768 and 40960. The batch is deliberately **skewed** (one long sequence among short ones). A single long sequence would be caught by a capacity-style guard and would therefore mask the page-table divergence described above.

2. **`test_gqa_sliding_window_beyond_int16_span`** — no test in the repo previously paired a `sliding_window` with a sequence past the cliff, even though the window predicate rides on the exact same narrowed arithmetic.

3. **`test_sliding_window_narrower_than_sequence_prefill_accuracy`** — a window that actually cuts *inside* a query tile, reached through the production metadata path.

That third case is coverage rather than a witness — it passes on main. Both sliding-window tests in `test_flashattention_misc.py` use a window *wider* than every sequence they run, so their predicate is uniformly true across every tile the kernel visits and they would still pass with the sliding-window arm deleted entirely. `test_rpa_v3_kv_writeback.py` does cut its window, but it calls `ragged_paged_attention` directly with a hand-built page table; this case reaches the kernel through `RadixAttention` and the `FlashAttention` backend, so `page_indices` and `cu_kv_lens` are built by `_pad_page_indices` the way they are in production.

Test command:

```bash
python -m pytest python/sgl_jax/test/test_flashattention_gqa.py python/sgl_jax/test/test_flashattention_misc.py -q
```

Beyond the suite, the rewrite was validated by an exhaustive sweep over 306k states (tile shapes × mask combinations × window sizes × tile bases × `delta` scans), modelling the narrowing as Mosaic's wrapping `arith.trunci`. The new path matches a reference oracle everywhere, and matches the **current** kernel bit-for-bit in all 260,388 states where the current kernel is already correct — so short contexts are unaffected.

## Benchmarking and Profiling

The `int16` vectorization path is fully preserved. The selection condition is unchanged apart from a static tile-size assertion, so **every shape that took the fast path before still takes it** — and it is now completely unconstrained by sequence length, whereas a capacity-style guard would surrender it exactly where long-context serving lives.

No new runtime work is introduced: `k_span` and `v_span` each lose a broadcast add (they are bare iotas now), and two `int32` scalar clamps are added.

## Checklist

- [x] Please use English, otherwise it will be closed.
- [x] The purpose of the PR, or link existing issues this PR will resolve.
- [x] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
