### PR TITLE
feat(moe): opt-in SparseCore permute/unpermute kernels for EPMoE (110k TTFT -5.4%)

### DIFF
--- a/python/sgl_jax/srt/kernels/sparse_core/__init__.py
+++ b/python/sgl_jax/srt/kernels/sparse_core/__init__.py
@@ -1,0 +1,1 @@
+"""SparseCore Pallas kernels (vendored from vllm-project/tpu-inference) and MoE permute wrappers."""

--- a/python/sgl_jax/srt/kernels/sparse_core/_logging.py
+++ b/python/sgl_jax/srt/kernels/sparse_core/_logging.py
@@ -1,0 +1,20 @@
+"""Minimal ``init_logger`` shim so the vendored tpu-inference kernels keep their logging calls."""
+
+import logging
+
+
+class _OnceLogger(logging.LoggerAdapter):
+    def __init__(self, logger):
+        super().__init__(logger, {})
+        self._seen: set[str] = set()
+
+    def warning_once(self, msg, *args, **kwargs):
+        key = msg % args if args else str(msg)
+        if key in self._seen:
+            return
+        self._seen.add(key)
+        self.warning(msg, *args, **kwargs)
+
+
+def init_logger(name: str) -> _OnceLogger:
+    return _OnceLogger(logging.getLogger(name))

--- a/python/sgl_jax/srt/kernels/sparse_core/core_map_helper.py
+++ b/python/sgl_jax/srt/kernels/sparse_core/core_map_helper.py
@@ -1,0 +1,77 @@
+# Adapted from https://github.com/vllm-project/tpu-inference/blob/main/tpu_inference/kernels/sparse_core/core_map_helper.py
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Run single-mesh SparseCore kernels through ``core_map``.
+
+``pl.kernel`` lowers through ``mpmd_map``, which is slower than the ``core_map``
+path for these single-mesh kernels on TPU. ``kernel`` here is a drop-in
+replacement for ``pl.kernel`` that uses ``core_map`` directly, so the SparseCore
+kernels keep that lowering without depending on the jax-side ``pl.kernel``
+implementation.
+"""
+
+from jax._src import api
+from jax._src import core as jax_core
+from jax._src import lax, tree_util
+from jax._src.pallas import core as pl_core
+
+
+def _empty_out_ref(out_type):
+    aval = pl_core._convert_out_shape_to_aval(out_type)
+    memory_space = (
+        None if isinstance(aval.memory_space, jax_core.MemorySpace) else aval.memory_space
+    )
+    value = lax.empty(aval.shape, aval.dtype, out_sharding=aval.sharding)
+    return jax_core.new_ref(value, memory_space=memory_space)
+
+
+def kernel(
+    body,
+    *,
+    out_type,
+    mesh,
+    scratch_types=(),
+    compiler_params=None,
+    interpret=False,
+    cost_estimate=None,
+    debug=False,
+    name=None,
+    metadata=None,
+):
+    """Drop-in replacement for ``pl.kernel`` that lowers via ``core_map``."""
+    single_output = not isinstance(out_type, (tuple, list))
+    out_types = (out_type,) if single_output else out_type
+
+    @api.jit
+    def run(*operands):
+        arg_refs = tree_util.tree_map(jax_core.new_ref, operands)
+        out_refs = tree_util.tree_map(_empty_out_ref, out_types)
+
+        @pl_core.core_map(
+            mesh,
+            scratch_shapes=scratch_types,
+            compiler_params=compiler_params,
+            interpret=interpret,
+            cost_estimate=cost_estimate,
+            debug=debug,
+            name=name,
+            metadata=metadata,
+        )
+        def _(*scratch_refs, **scratch_kwrefs):
+            return body(*arg_refs, *out_refs, *scratch_refs, **scratch_kwrefs)
+
+        outs = tree_util.tree_map(lambda ref: ref[...], out_refs)
+        return outs[0] if single_output else outs
+
+    return run

--- a/python/sgl_jax/srt/kernels/sparse_core/moe_permute.py
+++ b/python/sgl_jax/srt/kernels/sparse_core/moe_permute.py
@@ -56,6 +56,22 @@ def _small_for_sparse_core(nbytes: int) -> bool:
     return nbytes * 2 < _tc_vmem_bytes() * _SMALL_INPUT_VMEM_FRACTION
 
 
+def should_use_sparse_core(num_rows: int, hidden: int, dtype) -> bool:
+    """Trace-time decision shared by EPMoE and the wrappers below.
+
+    False means "emit exactly the XLA formulation" -- callers must not add any
+    masking/range bookkeeping in that case, so decode-sized batches keep an HLO
+    identical to the flag-off path (and hit the same compilation cache).
+    """
+    nbits = jax.dtypes.itemsize_bits(dtype)
+    return (
+        sparse_core_available()
+        and nbits in _SUPPORTED_GATHER_BITS
+        and hidden % 128 == 0
+        and not _small_for_sparse_core(num_rows * hidden * nbits // 8)
+    )
+
+
 def reference_combine(
     intermediate: jax.Array, revert_indices: jax.Array, weights: jax.Array, top_k: int
 ) -> jax.Array:
@@ -75,14 +91,7 @@ def sc_dispatch_gather(
     Rows outside the range are never read by the grouped matmul (they belong to
     other devices' experts), so skipping them is what makes this cheaper than XLA.
     """
-    rows, hidden = token_indices.shape[0], inputs_2d.shape[-1]
-    nbits = jax.dtypes.itemsize_bits(inputs_2d.dtype)
-    if (
-        not sparse_core_available()
-        or nbits not in _SUPPORTED_GATHER_BITS
-        or hidden % 128 != 0
-        or _small_for_sparse_core(rows * hidden * nbits // 8)
-    ):
+    if not should_use_sparse_core(token_indices.shape[0], inputs_2d.shape[-1], inputs_2d.dtype):
         return inputs_2d[token_indices]
     from sgl_jax.srt.kernels.sparse_core.ragged_gather_v2 import ragged_gather_v2
 
@@ -101,13 +110,12 @@ def sc_combine(
     ``valid_mask[i]`` marks whether routed slot ``i`` (token-major order) hit a
     local expert; masked rows contribute zero regardless of their contents.
     """
-    hidden = intermediate.shape[-1]
     if (
-        not sparse_core_available()
-        or intermediate.dtype != jnp.bfloat16
+        intermediate.dtype != jnp.bfloat16
         or weights.dtype not in (jnp.float32, jnp.bfloat16)
-        or hidden % 128 != 0
-        or _small_for_sparse_core(intermediate.size * 2)
+        or not should_use_sparse_core(
+            intermediate.shape[0], intermediate.shape[-1], intermediate.dtype
+        )
     ):
         masked = jnp.where(valid_mask.reshape(-1, 1), weights.reshape(-1, 1), 0).reshape(-1)
         return reference_combine(intermediate, revert_indices, masked, top_k)

--- a/python/sgl_jax/srt/kernels/sparse_core/moe_permute.py
+++ b/python/sgl_jax/srt/kernels/sparse_core/moe_permute.py
@@ -1,0 +1,124 @@
+"""SparseCore-backed MoE permute (dispatch gather) and unpermute (weighted combine).
+
+Why: on TPU the XLA gather offload already runs MoE gathers on SparseCore, but it
+cannot express the expert-parallel semantics ``EPMoE`` needs -- it gathers every
+``tokens * top_k`` row (all experts) even though a device only computes its own
+expert slice, and the combine gather + einsum is exposed on the TensorCore. The
+tpu-inference kernels vendored next to this module gather only the local row
+range (``ragged_gather_v2``) and fuse gather + top-k weighted reduce
+(``ragged_gather_reduce``).
+
+Both entry points fall back to the plain XLA formulation whenever SparseCore is
+unavailable or the problem is too small for the offload to pay off, so callers
+can use them unconditionally once the opt-in is on.
+"""
+
+import functools
+import logging
+
+import jax
+import jax.numpy as jnp
+from jax.experimental.pallas import tpu as pltpu
+
+from sgl_jax.srt.utils.common_utils import get_bool_env_var
+
+logger = logging.getLogger(__name__)
+
+# Opt-in switch (default off) read by EPMoE when ``use_sc_permute`` is not given.
+ENV_FLAG = "SGL_JAX_MOE_SC_PERMUTE"
+
+# Below this fraction of TensorCore VMEM a plain TC gather beats the SC round-trip
+# (same heuristic tpu-inference uses inside ragged_gather_reduce).
+_SMALL_INPUT_VMEM_FRACTION = 0.6
+_SUPPORTED_GATHER_BITS = (8, 16, 32)
+
+
+def moe_sc_permute_enabled_by_env() -> bool:
+    return get_bool_env_var(ENV_FLAG, "false")
+
+
+@functools.lru_cache(maxsize=1)
+def sparse_core_available() -> bool:
+    try:
+        if jax.devices()[0].platform != "tpu":
+            return False
+        return pltpu.get_tpu_info().sparse_core is not None
+    except Exception as e:  # noqa: BLE001 - any probe failure means "not available"
+        logger.debug("SparseCore probe failed: %s", e)
+        return False
+
+
+def _tc_vmem_bytes() -> int:
+    return int(pltpu.get_tpu_info().vmem_capacity_bytes)
+
+
+def _small_for_sparse_core(nbytes: int) -> bool:
+    return nbytes * 2 < _tc_vmem_bytes() * _SMALL_INPUT_VMEM_FRACTION
+
+
+def reference_combine(
+    intermediate: jax.Array, revert_indices: jax.Array, weights: jax.Array, top_k: int
+) -> jax.Array:
+    """XLA formulation of EPMoE unpermute: gather back to token order, weighted sum over top_k."""
+    total_tokens = revert_indices.shape[0] // top_k
+    unsorted = jnp.take(intermediate, indices=revert_indices, axis=0)
+    unsorted = unsorted.reshape(total_tokens, top_k, -1).astype(jnp.float32)
+    w = weights.reshape(total_tokens, top_k).astype(jnp.float32)
+    return jnp.einsum("BKE,BK -> BE", unsorted, w).astype(intermediate.dtype)
+
+
+def sc_dispatch_gather(
+    inputs_2d: jax.Array, token_indices: jax.Array, start: jax.Array, end: jax.Array
+) -> jax.Array:
+    """``inputs_2d[token_indices]`` where only rows ``[start, end)`` are guaranteed valid.
+
+    Rows outside the range are never read by the grouped matmul (they belong to
+    other devices' experts), so skipping them is what makes this cheaper than XLA.
+    """
+    rows, hidden = token_indices.shape[0], inputs_2d.shape[-1]
+    nbits = jax.dtypes.itemsize_bits(inputs_2d.dtype)
+    if (
+        not sparse_core_available()
+        or nbits not in _SUPPORTED_GATHER_BITS
+        or hidden % 128 != 0
+        or _small_for_sparse_core(rows * hidden * nbits // 8)
+    ):
+        return inputs_2d[token_indices]
+    from sgl_jax.srt.kernels.sparse_core.ragged_gather_v2 import ragged_gather_v2
+
+    return ragged_gather_v2(inputs_2d, token_indices, start, end)
+
+
+def sc_combine(
+    intermediate: jax.Array,
+    revert_indices: jax.Array,
+    weights: jax.Array,
+    valid_mask: jax.Array,
+    top_k: int,
+) -> jax.Array:
+    """Weighted top-k combine of sorted expert outputs back into token order.
+
+    ``valid_mask[i]`` marks whether routed slot ``i`` (token-major order) hit a
+    local expert; masked rows contribute zero regardless of their contents.
+    """
+    hidden = intermediate.shape[-1]
+    if (
+        not sparse_core_available()
+        or intermediate.dtype != jnp.bfloat16
+        or weights.dtype not in (jnp.float32, jnp.bfloat16)
+        or hidden % 128 != 0
+        or _small_for_sparse_core(intermediate.size * 2)
+    ):
+        masked = jnp.where(valid_mask.reshape(-1, 1), weights.reshape(-1, 1), 0).reshape(-1)
+        return reference_combine(intermediate, revert_indices, masked, top_k)
+    from sgl_jax.srt.kernels.sparse_core.ragged_gather_reduce_v2 import (
+        ragged_gather_reduce,
+    )
+
+    return ragged_gather_reduce(
+        intermediate,
+        revert_indices,
+        weights.reshape(-1),
+        valid_mask.reshape(-1).astype(jnp.bool_),
+        top_k,
+    )

--- a/python/sgl_jax/srt/kernels/sparse_core/ragged_gather_reduce_tuned_params.py
+++ b/python/sgl_jax/srt/kernels/sparse_core/ragged_gather_reduce_tuned_params.py
@@ -1,0 +1,168 @@
+# Adapted from https://github.com/vllm-project/tpu-inference/blob/main/tpu_inference/kernels/sparse_core/ragged_gather_reduce_tuned_params.py
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+
+from sgl_jax.srt.kernels.sparse_core._logging import init_logger
+
+logger = init_logger(__name__)
+
+
+@dataclass(frozen=True)
+class TuningKey:
+    """Fixed parameters that define a ragged gather reduce problem shape."""
+
+    input_size: int
+    hidden_size: int
+    reduce_group_size: int
+    dtype: str = "bfloat16"
+
+
+@dataclass(frozen=True)
+class TunableParams:
+    """Tuning parameters for the ragged gather reduce kernel."""
+
+    num_column_partitions: int
+    num_row_partitions: int
+    num_row_subchunks: int
+    row_chunk_size: int
+    aligned_hidden_size: int
+    col_size: int
+    col_chunk_size: int
+
+    def __ge__(self, other) -> bool:
+        if not isinstance(other, TunableParams):
+            return NotImplemented
+        return (
+            self.num_column_partitions >= other.num_column_partitions
+            and self.num_row_partitions >= other.num_row_partitions
+            and self.num_row_subchunks >= other.num_row_subchunks
+            and self.row_chunk_size >= other.row_chunk_size
+            and self.aligned_hidden_size >= other.aligned_hidden_size
+            and self.col_size >= other.col_size
+            and self.col_chunk_size >= other.col_chunk_size
+        )
+
+    def __le__(self, other) -> bool:
+        if not isinstance(other, TunableParams):
+            return NotImplemented
+        return (
+            self.num_column_partitions <= other.num_column_partitions
+            and self.num_row_partitions <= other.num_row_partitions
+            and self.num_row_subchunks <= other.num_row_subchunks
+            and self.row_chunk_size <= other.row_chunk_size
+            and self.aligned_hidden_size <= other.aligned_hidden_size
+            and self.col_size <= other.col_size
+            and self.col_chunk_size <= other.col_chunk_size
+        )
+
+
+tuned_params_mapping: dict[TuningKey, TunableParams] = {
+    TuningKey(
+        input_size=4096,
+        hidden_size=2816,
+        reduce_group_size=8,
+        dtype="bfloat16",
+    ): TunableParams(
+        num_column_partitions=2,
+        num_row_partitions=16,
+        num_row_subchunks=4,
+        row_chunk_size=64,
+        aligned_hidden_size=2816,
+        col_size=1408,
+        col_chunk_size=1408,
+    ),
+    TuningKey(
+        input_size=8192,
+        hidden_size=2816,
+        reduce_group_size=8,
+        dtype="bfloat16",
+    ): TunableParams(
+        num_column_partitions=2,
+        num_row_partitions=16,
+        num_row_subchunks=4,
+        row_chunk_size=64,
+        aligned_hidden_size=2816,
+        col_size=1408,
+        col_chunk_size=1408,
+    ),
+    TuningKey(
+        input_size=16384,
+        hidden_size=2816,
+        reduce_group_size=8,
+        dtype="bfloat16",
+    ): TunableParams(
+        num_column_partitions=2,
+        num_row_partitions=16,
+        num_row_subchunks=4,
+        row_chunk_size=64,
+        aligned_hidden_size=2816,
+        col_size=1408,
+        col_chunk_size=1408,
+    ),
+    TuningKey(
+        input_size=32768,
+        hidden_size=2816,
+        reduce_group_size=8,
+        dtype="bfloat16",
+    ): TunableParams(
+        num_column_partitions=2,
+        num_row_partitions=16,
+        num_row_subchunks=4,
+        row_chunk_size=64,
+        aligned_hidden_size=2816,
+        col_size=1408,
+        col_chunk_size=1408,
+    ),
+    TuningKey(
+        input_size=65536,
+        hidden_size=2816,
+        reduce_group_size=8,
+        dtype="bfloat16",
+    ): TunableParams(
+        num_column_partitions=2,
+        num_row_partitions=16,
+        num_row_subchunks=4,
+        row_chunk_size=64,
+        aligned_hidden_size=2816,
+        col_size=1408,
+        col_chunk_size=1408,
+    ),
+    TuningKey(
+        input_size=131072,
+        hidden_size=2816,
+        reduce_group_size=8,
+        dtype="bfloat16",
+    ): TunableParams(
+        num_column_partitions=2,
+        num_row_partitions=16,
+        num_row_subchunks=4,
+        row_chunk_size=64,
+        aligned_hidden_size=2816,
+        col_size=1408,
+        col_chunk_size=1408,
+    ),
+}
+
+
+def get_tuned_params(tuning_key: TuningKey) -> TunableParams | None:
+    """Looks up tuned parameters for ragged_gather_reduce."""
+    tuned_params = tuned_params_mapping.get(tuning_key)
+    if tuned_params is None:
+        logger.warning_once(
+            f"No tuned params found for ragged_gather_reduce with ke0y: {tuning_key}, "
+            "falling back to default heuristic."
+        )
+    return tuned_params

--- a/python/sgl_jax/srt/kernels/sparse_core/ragged_gather_reduce_v2.py
+++ b/python/sgl_jax/srt/kernels/sparse_core/ragged_gather_reduce_v2.py
@@ -1,0 +1,754 @@
+# Adapted from https://github.com/vllm-project/tpu-inference/blob/main/tpu_inference/kernels/sparse_core/ragged_gather_reduce_v2.py
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import dataclasses
+import functools
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+from jax.experimental.pallas import tpu_sc as plsc
+
+from sgl_jax.srt.kernels.sparse_core import core_map_helper
+from sgl_jax.srt.kernels.sparse_core.ragged_gather_reduce_tuned_params import (
+    TunableParams,
+    TuningKey,
+    get_tuned_params,
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class _Config:
+    num_row_partitions: int
+    num_column_partitions: int
+    reduce_group_size: int
+    col_size: int
+    col_chunk_size: int
+    num_row_subchunks: int
+    num_simd_lanes: int
+    topk_dtype: Any
+    in_dtype: Any
+    core_axis_name: str
+    subcore_axis_name: str
+
+    @property
+    def row_chunk_size(self) -> int:
+        """Number of rows handled per row-pipeline block."""
+        return self.num_simd_lanes * self.num_row_subchunks
+
+    @property
+    def row_shift(self) -> int:
+        """log2 of how many source rows pack into one uint32 gather element.
+
+        The SparseCore indirect DMA requires 32-bit elements: bfloat16 packs two
+        source rows per uint32 (shift 1), float32 is 1:1 (shift 0).
+        """
+        input_packing = 32 // jax.dtypes.itemsize_bits(self.in_dtype)
+        return input_packing.bit_length() - 1
+
+
+@jax.tree_util.register_dataclass
+@dataclasses.dataclass(frozen=True)
+class _Inputs:
+    num_src_rows_per_row_partition: Any
+    x: Any
+    indices: Any
+    topk_weights: Any
+    sorted_by_validity: Any
+
+
+@jax.tree_util.register_dataclass
+@dataclasses.dataclass(frozen=True)
+class _Scratch:
+    num_rows_per_row_partition_vmem: Any
+    prev_iter_last_row_vmem: Any
+    prev_dst_row_smem: Any
+    sorted_by_validity_vmem: Any
+    src_indices_vmem: Any
+    dst_indices_vmem: Any
+    tw_f32_vmem: Any
+    dma_src_row_vmem: Any
+    dma_dst_row_vmem: Any
+    prev_dst_val_vmem: Any
+    out_vmem: Any
+    sem: Any
+
+    def __len__(self) -> int:
+        return len(dataclasses.fields(self))
+
+    def __getitem__(self, index: Any):
+        return getattr(self, dataclasses.fields(self)[index].name)
+
+
+class _CostModelConstants:
+    # Limit on the number of outer loop pipeline iterations. Too many iterations
+    # cause high cumulative pipeline overhead (e.g., from frequent pipeline
+    # startup/teardown bubbles). We try to find partitioning that does not exceed
+    # this limit on iterations.
+    MAX_ITERATIONS: int = 40
+
+    # Upper cap on the column chunk size processed per inner pipeline step.
+    # While larger chunk sizes help utilize bandwidth better, excessively large
+    # chunk sizes cause large pipeline bubbles. We cap it here to balance
+    # efficiency and bubble sizes.
+    MAX_COL_CHUNK_SIZE: int = 1024
+
+
+# ceil up to the nearest multiple of b.
+def _align_to(a, b):
+    return pl.cdiv(a, b) * b
+
+
+def _fallback_implementation(
+    x: jax.Array,
+    indices: jax.Array,
+    topk_weights: jax.Array,
+    valid_rows_mask: jax.Array,
+    reduce_group_size: int,
+) -> jax.Array:
+    out = x[indices] * topk_weights[:, None].astype(jnp.float32)
+    out = jnp.where(valid_rows_mask[:, None], out, 0)
+    out = out.reshape(-1, reduce_group_size, out.shape[-1])
+    out = jnp.sum(out, axis=1).astype(jnp.bfloat16)
+    return out
+
+
+def _calculate_num_column_partitions(
+    hidden_size: int, input_size: int, num_cores: int, num_lanes: int, num_simd_lanes: int
+) -> int:
+    """Calculates the number of row partitions."""
+    # Each column partition should be multiple of 128 (number of lanes) due to
+    # DMA requirements.
+    # Prefer to use a large number of column partitions, as long as each
+    # partition's size is not too small for DMA pipeline efficiency and each
+    # partition's size can divide the hidden size.
+
+    # Each column partition will do DMA pipelining on col_size.
+    preferred_num_stages = 4
+    num_column_partitions = 1
+    while (
+        num_cores % (num_column_partitions * 2) == 0
+        and hidden_size % (num_lanes * num_column_partitions * 2) == 0
+        and hidden_size // (num_column_partitions * 2 * num_lanes) >= preferred_num_stages
+    ):
+        next_candidate = num_column_partitions * 2
+        next_row_partitions = num_cores // next_candidate
+
+        # Calculate exactly how many pipeline invocations (outer loop)
+        num_row_subchunks, row_chunk_size = _calculate_row_tiling(
+            input_size, num_simd_lanes, next_row_partitions
+        )
+        num_iterations = input_size // (row_chunk_size * next_row_partitions)
+
+        # Ensure we satisfy the hardware constraint (num_row_partitions <= num_simd_lanes) first.
+        if num_cores // num_column_partitions > num_simd_lanes:
+            num_column_partitions = next_candidate
+            continue
+
+        # Too many iterations cause high cumulative pipeline overhead. Set the
+        # limit based on empirical data.
+        if num_iterations > _CostModelConstants.MAX_ITERATIONS:
+            break
+
+        num_column_partitions = next_candidate
+
+    return num_column_partitions
+
+
+def _calculate_row_tiling(
+    input_size: int,
+    num_simd_lanes: int,
+    num_row_partitions: int,
+) -> tuple[int, int]:
+    """Calculates the number of row subchunks and row chunk size."""
+    base_block_size = num_simd_lanes * num_row_partitions
+    num_row_subchunks = max(1, min(4, pl.cdiv(input_size, base_block_size)))
+    row_chunk_size = num_simd_lanes * num_row_subchunks
+    return num_row_subchunks, row_chunk_size
+
+
+def _calculate_col_chunk_size(col_size: int, num_simd_lanes: int) -> int:
+    """Picks the column chunk size the inner pipeline gathers at a time.
+
+    The chunk is the largest divisor of ``col_size`` whose gather double-buffer
+    still fits comfortably in SparseCore VMEM.
+    """
+    generation = pltpu.get_tpu_info().generation
+    match generation:
+        case 6:
+            target_bytes = int(256 * 1024 * 0.95)
+        case 7:
+            target_bytes = int(512 * 1024 * 0.95)
+        case _:
+            target_bytes = int(128 * 1024 * 0.95)
+
+    # uint32 gather buffer, double-buffered by emit_pipeline.
+    bytes_per_col = num_simd_lanes * 4 * 2
+    max_safe_col = (target_bytes // bytes_per_col // 128) * 128
+
+    # Larger chunk sizes cause larger pipeline bubbles, so cap it at 1024.
+    max_safe_col = min(max_safe_col, _CostModelConstants.MAX_COL_CHUNK_SIZE)
+    start_col = (min(col_size, max_safe_col) // 128) * 128
+    for chunk in range(start_col, 127, -128):
+        if col_size % chunk == 0:
+            return chunk
+    return 128
+
+
+def _preprocess(
+    valid_rows_mask: jax.Array,
+    reduce_group_size: int,
+    num_row_partitions: int,
+    num_simd_lanes: int,
+    row_chunk_size: int,
+) -> tuple[jax.Array, jax.Array, jax.Array]:
+    """Sorts valid source rows to the front of each row partition.
+
+    Returns:
+      sorted_by_validity: original row index of each slot after the stable
+        sort, flattened across partitions and padded to ``row_chunk_size``.
+      num_src_rows_per_row_partition: valid row count per partition, padded to
+        ``num_simd_lanes`` so the kernel can load it as a single vector.
+      mask: per output group, whether the group has any valid source row.
+    """
+    row_partition_size = valid_rows_mask.shape[0] // num_row_partitions
+    valid_rows_mask_2d = valid_rows_mask.reshape(num_row_partitions, -1)
+
+    # Stable sort of a boolean key is a stable partition: valid rows keep their
+    # relative order and move ahead of the invalid ones.
+    sorted_by_validity = jnp.argsort(~valid_rows_mask_2d, descending=False, stable=True, axis=-1)
+    sorted_by_validity += jnp.arange(num_row_partitions)[:, None] * row_partition_size
+
+    pad_to = _align_to(row_partition_size, row_chunk_size)
+    if pad_to > row_partition_size:
+        sorted_by_validity = jnp.pad(
+            sorted_by_validity,
+            ((0, 0), (0, pad_to - row_partition_size)),
+            constant_values=0,
+        )
+    sorted_by_validity = sorted_by_validity.reshape(-1)
+
+    num_src_rows_per_row_partition = jnp.pad(
+        jnp.sum(valid_rows_mask_2d, axis=-1).astype(jnp.int32),
+        (0, max(0, num_simd_lanes - num_row_partitions)),
+    )
+    mask = jnp.any(valid_rows_mask.reshape(-1, reduce_group_size), axis=-1)
+    return (
+        sorted_by_validity.astype(jnp.int32),
+        num_src_rows_per_row_partition,
+        mask,
+    )
+
+
+def _pack_scalars_to_vector(scalar_list: list[jax.Array], num_simd_lanes: int) -> jax.Array:
+    """Builds a lane vector from per-lane scalars.
+
+    SparseCore cannot store individual scalars into VMEM lanes, so the vector is
+    assembled with masked accumulation before being stored.
+    """
+    idx_vec = jnp.arange(num_simd_lanes)
+    vec = jnp.zeros((num_simd_lanes,), jnp.int32)
+    for i in range(num_simd_lanes):
+        vec += (idx_vec == i).astype(jnp.int32) * scalar_list[i]
+    return vec
+
+
+def _row_gather_spec(
+    sorted_by_validity_vmem: jax.Ref,
+    sub: int,
+    *,
+    num_simd_lanes: int,
+    row_chunk_size: int,
+) -> pl.BlockSpec:
+    """Indirect BlockSpec gathering sub-chunk ``sub``'s rows of a 1-D input."""
+    return pl.BlockSpec(
+        (pl.Indirect(num_simd_lanes),),
+        lambda i, s=sub: (
+            sorted_by_validity_vmem[pl.ds(i * row_chunk_size + s * num_simd_lanes, num_simd_lanes)],
+        ),
+    )
+
+
+def main_kernel(
+    inputs: _Inputs,
+    out_hbm_ref: jax.Ref,
+    scratch: _Scratch,
+    *,
+    cfg: _Config,
+):
+    # Step 1: Resolve this core's row/column partition and its column slice.
+    num_simd_lanes = cfg.num_simd_lanes
+    col_chunk_size = cfg.col_chunk_size
+    num_row_subchunks = cfg.num_row_subchunks
+    row_chunk_size = cfg.row_chunk_size
+
+    num_col_chunks = cfg.col_size // col_chunk_size
+
+    core_id = jax.lax.axis_index((cfg.core_axis_name, cfg.subcore_axis_name))
+    row_partition_id = core_id // cfg.num_column_partitions
+    col_partition_id = core_id % cfg.num_column_partitions
+
+    row_partition_size_padded = inputs.sorted_by_validity.shape[0] // cfg.num_row_partitions
+    row_start_padded = row_partition_id * row_partition_size_padded
+    col_start = col_partition_id * cfg.col_size
+
+    # Step 2: Stage this partition's row count and sort permutation into VMEM.
+    recv_sem = scratch.sem.at[0]
+    num_rows_dma = pltpu.make_async_copy(
+        inputs.num_src_rows_per_row_partition.at[pl.ds(0, num_simd_lanes)],
+        scratch.num_rows_per_row_partition_vmem,
+        recv_sem,
+    )
+    sorted_dma = pltpu.make_async_copy(
+        inputs.sorted_by_validity.at[pl.ds(row_start_padded, row_partition_size_padded)],
+        scratch.sorted_by_validity_vmem,
+        recv_sem,
+    )
+    num_rows_dma.start()
+    sorted_dma.start()
+    num_rows_dma.wait()
+    sorted_dma.wait()
+
+    num_rows_per_row_partition = scratch.num_rows_per_row_partition_vmem[...]
+    num_rows_current_row_partition = jnp.array(0, jnp.int32)
+    for i in range(cfg.num_row_partitions):
+        num_rows_current_row_partition = jnp.where(
+            row_partition_id == i,
+            num_rows_per_row_partition[i],
+            num_rows_current_row_partition,
+        )
+    num_row_blocks = pl.cdiv(num_rows_current_row_partition, row_chunk_size)
+
+    # Step 3: Run the gather / weighted segmented-reduce / scatter pipeline.
+
+    # The SparseCore indirect DMA requires 32-bit elements, so x is gathered
+    # through a uint32 reinterpretation. bfloat16 packs two source rows per
+    # uint32 row (row index >> 1); float32 is 1:1 (row index unchanged).
+    in_32b_hbm_ref = inputs.x.bitcast(jnp.uint32)
+
+    # Sentinel for the cross-block reduction carry (no previous group).
+    scratch.prev_dst_row_smem[0] = -1
+
+    # One gather per sub-chunk for ``indices``, then the same for
+    # ``topk_weights``.
+    row_pipeline_in_specs = (
+        tuple(
+            _row_gather_spec(
+                scratch.sorted_by_validity_vmem,
+                sub,
+                num_simd_lanes=num_simd_lanes,
+                row_chunk_size=row_chunk_size,
+            )
+            for sub in range(num_row_subchunks)
+        )
+        * 2
+    )
+
+    @functools.partial(
+        pltpu.emit_pipeline,
+        grid=(num_row_blocks,),
+        in_specs=row_pipeline_in_specs,
+        out_specs=(),
+    )
+    def row_pipeline(*args):
+        src_indices_refs = args[:num_row_subchunks]
+        topk_weights_refs = args[num_row_subchunks : 2 * num_row_subchunks]
+        (
+            src_indices_vmem_sc,
+            dst_indices_vmem_sc,
+            tw_f32_vmem_sc,
+            dma_src_row_vmem_sc,
+            dma_dst_row_vmem_sc,
+            prev_dst_val_vmem_sc,
+            out_vmem_sc,
+            sem_sc,
+        ) = args[-8:]
+
+        row_block_id = pl.program_id(0)
+
+        # Destination output row of each source row in this block.
+        dst_indices_list = [
+            scratch.sorted_by_validity_vmem[
+                pl.ds(
+                    row_block_id * row_chunk_size + s * num_simd_lanes,
+                    num_simd_lanes,
+                )
+            ]
+            // cfg.reduce_group_size
+            for s in range(num_row_subchunks)
+        ]
+
+        # Stage the gathered indices/weights and the destinations in VMEM.
+        for s in range(num_row_subchunks):
+            sub = pl.ds(s * num_simd_lanes, num_simd_lanes)
+            src_indices_vmem_sc[sub] = src_indices_refs[s][...]
+            dst_indices_vmem_sc[sub] = dst_indices_list[s]
+
+            tw = topk_weights_refs[s][...]
+            if cfg.topk_dtype == jnp.bfloat16:
+                tw_f32 = plsc.bitcast(jnp.bitwise_left_shift(tw, 16), jnp.float32)
+            else:
+                tw_f32 = plsc.bitcast(tw, jnp.float32)
+            tw_f32_vmem_sc[sub] = tw_f32
+
+        # For each sub-chunk, the destination of the row just before it -- the
+        # seed for the segmented reduction's "same group as previous row" test.
+        for s in range(num_row_subchunks):
+            if s == 0:
+                prev_dst = scratch.prev_dst_row_smem[0]
+            else:
+                prev_dst = dst_indices_list[s - 1][num_simd_lanes - 1]
+            prev_dst_val_vmem_sc[pl.ds(s * num_simd_lanes, num_simd_lanes)] = jnp.broadcast_to(
+                prev_dst, (num_simd_lanes,)
+            )
+
+        def get_dst_idx(global_idx):
+            return dst_indices_list[global_idx // num_simd_lanes][global_idx % num_simd_lanes]
+
+        # For each source row, find the VMEM row that will hold its group's fully
+        # reduced value -- the last row of the group within this block. Scanning
+        # backwards, a row inherits its successor's merge target when they share
+        # a destination, otherwise it is its own target.
+        src_row_idx_in_vmem = []
+        row_valid_vec = []
+        for row_vmem_idx in reversed(range(row_chunk_size)):
+            global_row_idx = row_block_id * row_chunk_size + row_vmem_idx
+            row_valid_vec.append(global_row_idx < num_rows_current_row_partition)
+            if row_vmem_idx == row_chunk_size - 1:
+                src_row_idx_in_vmem.append(row_vmem_idx)
+            else:
+                same_group_as_next = jnp.logical_and(
+                    row_valid_vec[-2],
+                    get_dst_idx(row_vmem_idx) == get_dst_idx(row_vmem_idx + 1),
+                ).astype(jnp.int32)
+                src_row_idx_in_vmem.append(
+                    same_group_as_next * src_row_idx_in_vmem[-1]
+                    + (1 - same_group_as_next) * row_vmem_idx
+                )
+        src_row_idx_in_vmem.reverse()
+        row_valid_vec.reverse()
+
+        # Per source row, the (VMEM source row, HBM destination row) of its
+        # scatter. Rows whose group is not yet fully reduced in this sub-chunk,
+        # and padding rows, are routed to a throwaway row.
+        garbage_dst = out_hbm_ref.shape[0] - 1
+        dma_src_rows = []
+        dma_dst_rows = []
+        for s in range(num_row_subchunks):
+            sub_src = []
+            sub_dst = []
+            for i in range(num_simd_lanes):
+                global_idx = s * num_simd_lanes + i
+                merge_target = src_row_idx_in_vmem[global_idx]
+                is_final_write = jnp.logical_and(
+                    row_valid_vec[global_idx],
+                    merge_target < (s + 1) * num_simd_lanes,
+                )
+                sub_src.append(jnp.where(is_final_write, merge_target % num_simd_lanes, 0))
+                sub_dst.append(jnp.where(is_final_write, dst_indices_list[s][i], garbage_dst))
+            dma_src_rows.append(sub_src)
+            dma_dst_rows.append(sub_dst)
+
+        for s in range(num_row_subchunks):
+            sub = pl.ds(s * num_simd_lanes, num_simd_lanes)
+            dma_src_row_vmem_sc[sub] = _pack_scalars_to_vector(dma_src_rows[s], num_simd_lanes)
+            dma_dst_row_vmem_sc[sub] = _pack_scalars_to_vector(dma_dst_rows[s], num_simd_lanes)
+
+        @functools.partial(
+            pltpu.emit_pipeline,
+            grid=(num_row_subchunks, num_col_chunks),
+            in_specs=pl.BlockSpec(
+                (pl.Indirect(num_simd_lanes), col_chunk_size),
+                lambda s, c: (
+                    jnp.bitwise_right_shift(
+                        src_indices_vmem_sc[pl.ds(s * num_simd_lanes, num_simd_lanes)],
+                        cfg.row_shift,
+                    ),
+                    col_start // col_chunk_size + c,
+                ),
+            ),
+            out_specs=(),
+        )
+        def col_pipeline(gather_ref, sem_inner):
+            s = pl.program_id(0)
+            c = pl.program_id(1)
+            col_hbm_start = col_start + c * col_chunk_size
+            send_sem = sem_inner.at[1]
+
+            row_slice = pl.ds(s * num_simd_lanes, num_simd_lanes)
+            tw_slice = tw_f32_vmem_sc[row_slice]
+            dst_slice = dst_indices_vmem_sc[row_slice]
+            src_idx_slice = src_indices_vmem_sc[row_slice]
+            prev_dst_vals_vec = prev_dst_val_vmem_sc[row_slice]
+
+            def col_loop(col_compute_offset):
+                col_slice = pl.ds(col_compute_offset, num_simd_lanes)
+                # Running sum, seeded by the carry from the previous sub-chunk.
+                previous_accumulated_data = scratch.prev_iter_last_row_vmem[c, col_slice]
+
+                for row_src in range(num_simd_lanes):
+                    val_u32 = gather_ref[row_src, col_slice]
+                    if cfg.in_dtype == jnp.bfloat16:
+                        # The two bfloat16 rows packed in one uint32 word sit in the low
+                        # (even row) or high (odd row) 16 bits. Shift the wanted half
+                        # into the float32 sign/exponent position and clear the rest.
+                        shift = jnp.where(jnp.bitwise_and(src_idx_slice[row_src], 1) == 0, 16, 0)
+                        shifted = jnp.bitwise_and(
+                            jnp.left_shift(val_u32, shift), jnp.uint32(0xFFFF0000)
+                        )
+                        data_f32 = plsc.bitcast(shifted, jnp.float32)
+                    else:
+                        data_f32 = plsc.bitcast(val_u32, jnp.float32)
+                    data_f32 *= tw_slice[row_src]
+
+                    # Reduction: accumulate while the destination group is unchanged,
+                    # restart otherwise. Sorting guarantees rows of one group are
+                    # contiguous.
+                    dst_row_hbm = dst_slice[row_src]
+                    prev_dst = prev_dst_vals_vec[0] if row_src == 0 else dst_slice[row_src - 1]
+                    accumulated_data = jnp.where(
+                        dst_row_hbm == prev_dst,
+                        previous_accumulated_data + data_f32,
+                        data_f32,
+                    )
+                    previous_accumulated_data = accumulated_data
+
+                    # The output buffer stays float32: a bfloat16 output would be
+                    # (16, 128)-tiled and the per-row scatter below writes a single
+                    # row at an arbitrary, non-tile-aligned destination, which is only
+                    # legal for 32-bit elements. The cast happens in the wrapper.
+                    out_vmem_sc[row_src, col_slice] = accumulated_data
+                    if row_src == num_simd_lanes - 1:
+                        scratch.prev_iter_last_row_vmem[c, col_slice] = accumulated_data
+
+            plsc.parallel_loop(0, col_chunk_size, step=num_simd_lanes)(col_loop)
+
+            # Scatter every source row's reduced value to its output row. Rows
+            # that share a group write the same value (idempotent); rows routed to
+            # the garbage destination are harmless.
+            dma_src_row_slice = dma_src_row_vmem_sc[row_slice]
+            dma_dst_row_slice = dma_dst_row_vmem_sc[row_slice]
+            copies = []
+            for i in range(num_simd_lanes):
+                copy = pltpu.make_async_copy(
+                    out_vmem_sc.at[dma_src_row_slice[i], pl.ds(0, col_chunk_size)],
+                    out_hbm_ref.at[dma_dst_row_slice[i], pl.ds(col_hbm_start, col_chunk_size)],
+                    send_sem,
+                )
+                copy.start()
+                copies.append(copy)
+            for copy in copies:
+                copy.wait()
+
+        col_pipeline(in_32b_hbm_ref, scratches=(sem_sc,))
+        scratch.prev_dst_row_smem[0] = dst_indices_list[-1][num_simd_lanes - 1]
+
+    row_pipeline(
+        *([inputs.indices] * num_row_subchunks),
+        *([inputs.topk_weights] * num_row_subchunks),
+        scratches=(
+            scratch.src_indices_vmem,
+            scratch.dst_indices_vmem,
+            scratch.tw_f32_vmem,
+            scratch.dma_src_row_vmem,
+            scratch.dma_dst_row_vmem,
+            scratch.prev_dst_val_vmem,
+            scratch.out_vmem,
+            scratch.sem,
+        ),
+    )
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=(
+        "reduce_group_size",
+        "tunable_params",
+    ),
+)
+def ragged_gather_reduce(
+    x: jax.Array,
+    indices: jax.Array,
+    topk_weights: jax.Array,
+    valid_rows_mask: jax.Array,
+    reduce_group_size: int,
+    tunable_params: TunableParams | None = None,
+) -> jax.Array:
+    """Gathers ``x`` by ``indices``, weights and masks, then reduces by group.
+
+    Args:
+      x: 2-D input features, ``(num_rows, hidden_size)``.
+      indices: 1-D gather indices, ``(input_size,)``.
+      topk_weights: 1-D per-row weights, ``(input_size,)``.
+      valid_rows_mask: 1-D bool mask of valid gathered rows, ``(input_size,)``.
+      reduce_group_size: number of consecutive rows summed into one output row.
+      tunable_params: optional tuned parameters for the kernel.
+
+    Returns:
+      Reduced output, ``(input_size // reduce_group_size, hidden_size)``.
+    """
+    # Step 1: Choose the implementation (TensorCore fallback or SparseCore).
+    sc_info = pltpu.get_tpu_info().sparse_core
+    if sc_info is None:
+        return _fallback_implementation(
+            x, indices, topk_weights, valid_rows_mask, reduce_group_size
+        )
+
+    # For a small {input + output} both likely fit in TensorCore VMEM, where a
+    # plain TC gather-reduce beats routing through SparseCore and HBM. This
+    # also keeps the kernel off configs with num_row_partitions > num_simd_lanes.
+    dtype_bytes = jax.dtypes.itemsize_bits(x.dtype) // 8
+    if jnp.size(x) * dtype_bytes * 2 < pltpu.get_tpu_info().vmem_capacity_bytes * 0.6:
+        return _fallback_implementation(
+            x, indices, topk_weights, valid_rows_mask, reduce_group_size
+        )
+
+    # Step 2: Derive the kernel configuration (core grid and column tiling).
+    hidden_size = x.shape[-1]
+    input_size = indices.size
+    num_simd_lanes = sc_info.num_lanes
+    num_lanes = pltpu.get_tpu_info().num_lanes
+    num_cores = sc_info.num_cores * sc_info.num_subcores
+
+    if tunable_params is None:
+        tuning_key = TuningKey(
+            input_size=input_size,
+            hidden_size=hidden_size,
+            reduce_group_size=reduce_group_size,
+            dtype=jnp.dtype(x.dtype).name,
+        )
+        tunable_params = get_tuned_params(tuning_key)
+
+    if tunable_params is not None:
+        num_column_partitions = tunable_params.num_column_partitions
+        num_row_partitions = tunable_params.num_row_partitions
+        num_row_subchunks = tunable_params.num_row_subchunks
+        row_chunk_size = tunable_params.row_chunk_size
+        aligned_hidden_size = tunable_params.aligned_hidden_size
+        col_size = tunable_params.col_size
+        col_chunk_size = tunable_params.col_chunk_size
+    else:
+        num_column_partitions = _calculate_num_column_partitions(
+            hidden_size, input_size, num_cores, num_lanes, num_simd_lanes
+        )
+        num_row_partitions = num_cores // num_column_partitions
+        assert (
+            num_row_partitions <= num_simd_lanes
+        ), f"{num_row_partitions=} must be <= {num_simd_lanes=}"
+        num_row_subchunks, row_chunk_size = _calculate_row_tiling(
+            input_size, num_simd_lanes, num_row_partitions
+        )
+
+        aligned_hidden_size = _align_to(hidden_size, 128 * num_column_partitions)
+        col_size = aligned_hidden_size // num_column_partitions
+        col_chunk_size = _calculate_col_chunk_size(col_size, num_simd_lanes)
+
+    # Step 3: Pre-process inputs (weights, padding, sort by validity).
+    # The kernel gathers x through a uint32 reinterpretation; carry the weights
+    # the same way so they can be bitcast back to float32 on SparseCore.
+    if topk_weights.dtype == jnp.bfloat16:
+        topk_weights_u32 = jax.lax.bitcast_convert_type(topk_weights, jnp.uint16).astype(jnp.uint32)
+    else:
+        topk_weights_u32 = jax.lax.bitcast_convert_type(topk_weights, jnp.uint32)
+
+    # Pad the input so each row partition holds a whole number of reduce
+    # groups; no group is then split across two physical cores.
+    padded_input_size = _align_to(input_size, num_row_partitions * reduce_group_size)
+    valid_rows_mask = jnp.pad(
+        valid_rows_mask,
+        (0, padded_input_size - input_size),
+        constant_values=False,
+    )
+
+    sorted_by_validity, num_src_rows_per_row_partition, mask = _preprocess(
+        valid_rows_mask,
+        reduce_group_size,
+        num_row_partitions,
+        num_simd_lanes,
+        row_chunk_size,
+    )
+
+    # Step 4: Launch the SparseCore kernel.
+    vector_mesh = plsc.VectorSubcoreMesh(
+        num_cores=sc_info.num_cores,
+        num_subcores=sc_info.num_subcores,
+        core_axis_name="core",
+        subcore_axis_name="subcore",
+    )
+
+    cfg = _Config(
+        num_row_partitions=num_row_partitions,
+        num_column_partitions=num_column_partitions,
+        reduce_group_size=reduce_group_size,
+        col_size=col_size,
+        col_chunk_size=col_chunk_size,
+        num_row_subchunks=num_row_subchunks,
+        num_simd_lanes=num_simd_lanes,
+        topk_dtype=topk_weights.dtype,
+        in_dtype=x.dtype,
+        core_axis_name=vector_mesh.core_axis_name,
+        subcore_axis_name=vector_mesh.subcore_axis_name,
+    )
+
+    # The output gets one extra row: the kernel's garbage scatter destination.
+    out = core_map_helper.kernel(
+        functools.partial(main_kernel, cfg=cfg),
+        out_type=jax.ShapeDtypeStruct(
+            (padded_input_size // reduce_group_size + 1, aligned_hidden_size),
+            jnp.float32,
+        ),
+        compiler_params=pltpu.CompilerParams(
+            use_tc_tiling_on_sc=True,
+            disable_bounds_checks=True,
+            needs_layout_passes=False,
+        ),
+        scratch_types=(
+            _Scratch(
+                num_rows_per_row_partition_vmem=pltpu.VMEM((num_simd_lanes,), jnp.int32),
+                prev_iter_last_row_vmem=pltpu.VMEM(
+                    (col_size // col_chunk_size, col_chunk_size), jnp.float32
+                ),
+                prev_dst_row_smem=pltpu.SMEM((1,), jnp.int32),
+                sorted_by_validity_vmem=pltpu.VMEM(
+                    (sorted_by_validity.size // num_row_partitions,), jnp.int32
+                ),
+                src_indices_vmem=pltpu.VMEM((row_chunk_size,), jnp.int32),
+                dst_indices_vmem=pltpu.VMEM((row_chunk_size,), jnp.int32),
+                tw_f32_vmem=pltpu.VMEM((row_chunk_size,), jnp.float32),
+                dma_src_row_vmem=pltpu.VMEM((row_chunk_size,), jnp.int32),
+                dma_dst_row_vmem=pltpu.VMEM((row_chunk_size,), jnp.int32),
+                prev_dst_val_vmem=pltpu.VMEM((row_chunk_size,), jnp.int32),
+                out_vmem=pltpu.VMEM((num_simd_lanes, col_chunk_size), jnp.float32),
+                sem=pltpu.SemaphoreType.DMA((2,)),
+            ),
+        ),
+        mesh=vector_mesh,
+        name="sc_ragged_gather_reduce_v2",
+    )(
+        _Inputs(
+            num_src_rows_per_row_partition=num_src_rows_per_row_partition,
+            x=x,
+            indices=indices,
+            topk_weights=topk_weights_u32,
+            sorted_by_validity=sorted_by_validity,
+        ),
+    )
+
+    # Step 5: Post-process the output (drop padding, zero empty groups, cast).
+    out = out[: input_size // reduce_group_size, :hidden_size]
+    out = jnp.where(mask[: input_size // reduce_group_size, None], out, jnp.zeros_like(out))
+    return out.astype(x.dtype)

--- a/python/sgl_jax/srt/kernels/sparse_core/ragged_gather_v2.py
+++ b/python/sgl_jax/srt/kernels/sparse_core/ragged_gather_v2.py
@@ -1,0 +1,282 @@
+# Adapted from https://github.com/vllm-project/tpu-inference/blob/main/tpu_inference/kernels/sparse_core/ragged_gather_v2.py
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+
+import jax
+import jax.numpy as jnp
+from jax import lax
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+from jax.experimental.pallas import tpu_sc as plsc
+
+from sgl_jax.srt.kernels.sparse_core import core_map_helper
+
+
+def calculate_col_size(hidden_size: int, packing: int) -> int:
+    """Calculates the max column size bounded by VMEM limits and hidden_size divisibility."""
+    tpu_info = pltpu.get_tpu_info()
+    sc_info = tpu_info.sparse_core
+    assert sc_info is not None, "SparseCore info is missing."
+    lanes = sc_info.num_lanes
+
+    match tpu_info.generation:
+        case 6:
+            target_bytes = (256 * 1024) * 0.8
+        case 7:
+            target_bytes = (512 * 1024) * 0.8
+        case _:
+            target_bytes = (128 * 1024) * 0.8
+
+    # Calculate max safe column size based on VMEM budget and align to 128.
+    num_buffers = 2
+    bytes_per_col = (lanes + lanes // packing) * 4 * num_buffers
+    max_safe_col = int((target_bytes // bytes_per_col) // 128) * 128
+
+    # Search for the largest divisor of hidden_size bounded by max_safe_col.
+    # The first divisor found is the maximum.
+    start_col = (min(hidden_size, max_safe_col) // 128) * 128
+    for c in range(start_col, 127, -128):
+        if hidden_size % c == 0:
+            return c
+    return max_safe_col
+
+
+def main_kernel_v2(
+    start_ref: jax.Ref,
+    end_ref: jax.Ref,
+    in_hbm_ref: jax.Ref,
+    indices_hbm_ref: jax.Ref,
+    out_hbm_ref: jax.Ref,
+    start_vmem_ref: jax.Ref,
+    end_vmem_ref: jax.Ref,
+    sem_ref: jax.Ref,
+    *,
+    core_axis_name: str,
+    subcore_axis_name: str,
+    num_row_subchunks: int,
+):
+    tpu_info = pltpu.get_tpu_info()
+    sc_info = tpu_info.sparse_core
+    assert sc_info is not None
+    num_simd_lanes = sc_info.num_lanes
+    hidden_size = in_hbm_ref.shape[-1]
+    dtype_bits = jax.dtypes.itemsize_bits(out_hbm_ref.dtype)
+    packing = 32 // dtype_bits
+    col_size = calculate_col_size(hidden_size, packing)
+
+    assert isinstance(hidden_size, int), f"hidden_size must be int, got {type(hidden_size)}"
+    num_cores = jax.lax.axis_size((core_axis_name, subcore_axis_name))
+    row_subchunk_size = num_simd_lanes
+    row_chunk_size = row_subchunk_size * num_row_subchunks
+    block_size = row_chunk_size * num_cores
+
+    recv_sem = sem_ref.at[0]
+
+    copy_start = pltpu.make_async_copy(start_ref, start_vmem_ref.at[:1], recv_sem)
+    copy_end = pltpu.make_async_copy(end_ref, end_vmem_ref.at[:1], recv_sem)
+    copy_start.start()
+    copy_end.start()
+    copy_start.wait()
+    copy_end.wait()
+
+    start = start_vmem_ref[...][0]
+    end = end_vmem_ref[...][0]
+
+    block_start = start // block_size
+    block_end = pl.cdiv(end, block_size)
+    num_blocks = block_end - block_start
+    num_blocks = jnp.where(end <= start, 0, num_blocks)
+
+    num_cols = pl.cdiv(hidden_size, col_size)
+
+    dtype = out_hbm_ref.dtype
+    dtype_bits = jax.dtypes.itemsize_bits(dtype)
+    packing = 32 // dtype_bits
+
+    core_index = lax.axis_index((core_axis_name, subcore_axis_name))
+
+    # SparseCore `.bitcast()` leverages hardware Row-Packing for 16-bit -> 32-bit conversion.
+    # The logical row count halves, while physical column dimensions remain unchanged.
+    in_hbm_i32 = in_hbm_ref.bitcast(jnp.int32)
+    out_hbm_i32 = out_hbm_ref.bitcast(jnp.int32)
+
+    num_phys_cols = col_size
+
+    # The outer pipeline runs on the Vector Core, hoisting the integer arithmetic required
+    # to decode the row-packed indices. This prevents scalar-core instruction starvation
+    # during the execution of the indirect `in_specs` block lambdas.
+
+    # TODO(guoweij): The nested `emit_pipeline` design creates a pipeline bubble (DMA wait)
+    # when the inner pipeline empties and restarts with new indices. This is a known
+    # high-level API limitation, currently amortized by setting a large num_row_subchunks
+    # and shouldn't be an issue for most use cases. We should still monitor
+    # the bubble's impact on E2E performance and, if needed, manually reimplement
+    # this using primitive operations to eliminate the bubble entirely.
+
+    def col_loop(col_base, gather_ref, out_ref, idx_rem, unpack_col_chunk):
+        col_slice = pl.ds(col_base, unpack_col_chunk)
+        if packing == 1:
+            gather_dt = gather_ref.bitcast(dtype)
+            out_dt = out_ref.bitcast(dtype)
+            out_dt[:, col_slice] = gather_dt[:, col_slice]
+        else:
+            # Manual bitwise extraction and packing for packing >= 2 (bfloat16, int8, int4)
+            # bf16: 0xFFFF, int8: 0xFF, int4: 0xF
+            mask = (1 << dtype_bits) - 1
+            shift_multiplier = dtype_bits.bit_length() - 1
+            for i in range(num_simd_lanes // packing):
+                packed_row = jnp.zeros((1, unpack_col_chunk), dtype=jnp.int32)
+                for j in range(packing):
+                    k = i * packing + j
+                    dynamic_shift = jnp.left_shift(idx_rem[k], shift_multiplier)
+                    val = jnp.bitwise_right_shift(gather_ref[pl.ds(k, 1), col_slice], dynamic_shift)
+                    val = jnp.bitwise_and(val, mask)
+                    pack_shift = j * dtype_bits
+                    packed_row = jnp.bitwise_or(packed_row, jnp.left_shift(val, pack_shift))
+                out_ref[pl.ds(i, 1), col_slice] = packed_row
+
+    def inner_pipeline(gather_ref, out_ref, idx_ref, unpack_col_chunk):
+        row_slice = pl.ds(pl.program_id(0) * row_subchunk_size, row_subchunk_size)
+        subchunk_idxs = idx_ref[row_slice]
+        if packing > 1:
+            # Equivalent to `subchunk_idxs % packing`
+            idx_rem = jnp.bitwise_and(subchunk_idxs, packing - 1)
+        else:
+            idx_rem = jnp.zeros_like(subchunk_idxs)
+
+        col_loop_fn = functools.partial(
+            col_loop,
+            gather_ref=gather_ref,
+            out_ref=out_ref,
+            idx_rem=idx_rem,
+            unpack_col_chunk=unpack_col_chunk,
+        )
+        plsc.parallel_loop(0, num_phys_cols, step=unpack_col_chunk)(col_loop_fn)
+
+    def outer_pipeline(idx_ref):
+        b = pl.program_id(0)
+        b_global = b + block_start
+
+        unpack_col_chunk = 128
+        assert num_phys_cols % unpack_col_chunk == 0
+        shift_amount = packing.bit_length() - 1
+        pltpu.emit_pipeline(
+            functools.partial(inner_pipeline, idx_ref=idx_ref, unpack_col_chunk=unpack_col_chunk),
+            grid=(num_row_subchunks, num_cols),
+            in_specs=pl.BlockSpec(
+                (pl.Indirect(row_subchunk_size), num_phys_cols),
+                lambda r, col_id: (
+                    jnp.bitwise_right_shift(
+                        idx_ref[pl.ds(r * row_subchunk_size, row_subchunk_size)],
+                        shift_amount,
+                    ),
+                    col_id,
+                ),
+            ),
+            out_specs=pl.BlockSpec(
+                (row_subchunk_size // packing, num_phys_cols),
+                lambda r, col_id: (
+                    (b_global * num_cores + core_index) * num_row_subchunks + r,
+                    col_id,
+                ),
+            ),
+        )(in_hbm_i32, out_hbm_i32)
+
+    pltpu.emit_pipeline(
+        outer_pipeline,
+        grid=(num_blocks,),
+        in_specs=pl.BlockSpec(
+            (row_chunk_size,),
+            lambda b: ((b + block_start) * num_cores + core_index,),
+        ),
+    )(indices_hbm_ref)
+
+
+@jax.jit
+def ragged_gather_v2(
+    x: jax.Array, indices: jax.Array, start: jax.Array, end: jax.Array
+) -> jax.Array:
+    """Perform gather on indices within dynamic array start and end using BlockSpec."""
+
+    assert x.ndim == 2, "Ragged gather only supports 2d inputs."
+    assert indices.ndim == 1, "Ragged gather only supports 1d indices."
+
+    if jnp.isscalar(start):
+        start = start[None]
+    if jnp.isscalar(end):
+        end = end[None]
+
+    dtype = x.dtype
+    # any data type with a size of {4,8,16,32} should be fine
+    dtype_bits = jax.dtypes.itemsize_bits(dtype)
+    if dtype_bits not in (4, 8, 16, 32):
+        raise ValueError(
+            f"dtype bit width must be one of 4, 8, 16, or 32, but got {dtype_bits} ({dtype})"
+        )
+
+    sc_info = pltpu.get_tpu_info().sparse_core
+    if sc_info is None:
+        return x[indices]
+
+    hidden_size = x.shape[-1]
+    out_size = indices.size
+
+    packing = 32 // dtype_bits
+    col_size = calculate_col_size(hidden_size, packing)
+
+    aligned_hidden_size = ((hidden_size + col_size - 1) // col_size) * col_size
+
+    num_simd_lanes = sc_info.num_lanes
+    num_cores = sc_info.num_cores * sc_info.num_subcores
+    base_block_size = num_simd_lanes * num_cores
+
+    # Calculate ideal num_row_subchunks to avoid too much padding overhead.
+    num_row_subchunks = max(1, min(4, (out_size + base_block_size - 1) // base_block_size))
+
+    row_subchunk_size = num_simd_lanes
+    row_chunk_size = row_subchunk_size * num_row_subchunks
+    block_size = row_chunk_size * num_cores
+
+    out_pad_size = ((out_size + block_size - 1) // block_size) * block_size - out_size
+    indices = jnp.pad(indices, ((0, out_pad_size)))
+
+    vector_mesh = plsc.VectorSubcoreMesh(
+        num_cores=sc_info.num_cores,
+        num_subcores=sc_info.num_subcores,
+        core_axis_name="core",
+        subcore_axis_name="subcore",
+    )
+    return core_map_helper.kernel(
+        functools.partial(
+            main_kernel_v2,
+            core_axis_name=vector_mesh.core_axis_name,
+            subcore_axis_name=vector_mesh.subcore_axis_name,
+            num_row_subchunks=num_row_subchunks,
+        ),
+        out_type=jax.ShapeDtypeStruct((out_size + out_pad_size, aligned_hidden_size), dtype),
+        compiler_params=pltpu.CompilerParams(
+            use_tc_tiling_on_sc=True,
+            needs_layout_passes=True,
+            disable_bounds_checks=True,
+        ),
+        scratch_types=[
+            pltpu.VMEM((16,), jnp.int32),
+            pltpu.VMEM((16,), jnp.int32),
+            pltpu.SemaphoreType.DMA((1,)),
+        ],
+        mesh=vector_mesh,
+        name="sc_ragged_gather_v2",
+    )(start, end, x, indices)[:out_size, :hidden_size]

--- a/python/sgl_jax/srt/layers/moe.py
+++ b/python/sgl_jax/srt/layers/moe.py
@@ -16,6 +16,7 @@ from sgl_jax.srt.kernels.sparse_core.moe_permute import (
     moe_sc_permute_enabled_by_env,
     sc_combine,
     sc_dispatch_gather,
+    should_use_sparse_core,
 )
 
 # Re-export for backward compatibility: external code imports from this module.
@@ -632,7 +633,11 @@ class EPMoE(nnx.Module):
 
         local_range = None
         valid_mask = None
-        if self.use_sc_permute:
+        # Trace-time gate: small (decode-sized) batches keep the exact XLA path so
+        # their HLO is identical to the flag-off build.
+        if self.use_sc_permute and should_use_sparse_core(
+            token_indices.shape[0], inputs_2d.shape[-1], self.dtype
+        ):
             # Sorted-row range owned by this expert shard, and which routed slots
             # (token-major order) landed on a local expert.
             csum = jnp.cumsum(group_sizes)

--- a/python/sgl_jax/srt/layers/moe.py
+++ b/python/sgl_jax/srt/layers/moe.py
@@ -12,6 +12,11 @@ from jax.sharding import PartitionSpec as P
 
 from sgl_jax.srt.eplb.expert_location import get_global_expert_location_metadata
 from sgl_jax.srt.kernels.gmm.megablox_gmm_backend import gmm
+from sgl_jax.srt.kernels.sparse_core.moe_permute import (
+    moe_sc_permute_enabled_by_env,
+    sc_combine,
+    sc_dispatch_gather,
+)
 
 # Re-export for backward compatibility: external code imports from this module.
 from sgl_jax.srt.layers.fused_moe import FusedEPMoE, FusedEPMoEV2  # noqa: F401
@@ -41,8 +46,13 @@ class EPMoE(nnx.Module):
         physical_to_logical_map: "jax.Array | None" = None,
         pre_gather_quant_dtype=None,
         moe_dp_size: int = 1,
+        use_sc_permute: bool | None = None,
     ):
         self.num_experts_per_tok = num_experts_per_tok
+        # Opt-in SparseCore permute/unpermute kernels; ``None`` defers to the env flag.
+        self.use_sc_permute = (
+            moe_sc_permute_enabled_by_env() if use_sc_permute is None else bool(use_sc_permute)
+        )
         self.physical_to_logical_map = physical_to_logical_map
         self.pre_gather_quant_dtype = pre_gather_quant_dtype
         self.moe_dp_size = moe_dp_size
@@ -620,6 +630,21 @@ class EPMoE(nnx.Module):
 
         group_offset = self._dispatch(group_sizes, expert_shard_id)
 
+        local_range = None
+        valid_mask = None
+        if self.use_sc_permute:
+            # Sorted-row range owned by this expert shard, and which routed slots
+            # (token-major order) landed on a local expert.
+            csum = jnp.cumsum(group_sizes)
+            start = jnp.where(group_offset == 0, 0, csum[jnp.maximum(group_offset - 1, 0)])
+            end = csum[group_offset + self.experts_per_device - 1]
+            if self.ep_size > 1:
+                local_range = (start.astype(jnp.int32), end.astype(jnp.int32))
+            flat_experts = jnp.ravel(topk_ids)
+            valid_mask = (flat_experts >= group_offset) & (
+                flat_experts < group_offset + self.experts_per_device
+            )
+
         intermediate_output = self._gmm_compute(
             inputs_2d,
             token_indices,
@@ -634,12 +659,14 @@ class EPMoE(nnx.Module):
             w0_kernel_bias,
             w1_kernel_bias,
             wo_kernel_bias,
+            local_range=local_range,
         )
 
         output = self._unpermute(
             intermediate_output,
             sorted_selected_experts,
             topk_weights,
+            valid_mask=valid_mask,
         )
 
         # Reduce on the "tensor" axis. RS (psum_scatter) when caller asked
@@ -670,6 +697,7 @@ class EPMoE(nnx.Module):
         w0_kernel_bias=None,
         w1_kernel_bias=None,
         wo_kernel_bias=None,
+        local_range=None,
     ):
         if token_indices.shape[0] == 0:
             return jnp.zeros((0, wo_kernel.shape[-1]), dtype=inputs_2d.dtype)
@@ -683,6 +711,10 @@ class EPMoE(nnx.Module):
             x = x_q[token_indices]
             x_scale = x_scale[token_indices]
             x = (x.astype(jnp.float32) * x_scale).astype(self.dtype)
+        elif local_range is not None:
+            # SparseCore ragged gather: only rows [start, end) (local experts) are
+            # materialized; gmm never reads the others thanks to group_offset.
+            x = sc_dispatch_gather(inputs_2d, token_indices, *local_range).astype(self.dtype)
         else:
             x = inputs_2d[token_indices].astype(self.dtype)
 
@@ -803,7 +835,7 @@ class EPMoE(nnx.Module):
             group_sizes,
         )
 
-    def _unpermute(self, intermediate, sorted_selected_experts, weights):
+    def _unpermute(self, intermediate, sorted_selected_experts, weights, valid_mask=None):
         top_k = self.num_experts_per_tok
         if weights.ndim != 2 or weights.shape[1] != top_k:
             raise ValueError(
@@ -833,6 +865,17 @@ class EPMoE(nnx.Module):
             .at[sorted_selected_experts]
             .set(jnp.arange(expected_tokens, dtype=jnp.int32))
         )
+        if self.use_sc_permute and valid_mask is not None:
+            # SparseCore fused gather + top-k weighted reduce (falls back to XLA when
+            # SparseCore is absent or the problem is too small to benefit).
+            return sc_combine(
+                intermediate,
+                argsort_indices,
+                jnp.reshape(weights, (-1,)),
+                valid_mask,
+                self.num_experts_per_tok,
+            ).astype(self.dtype)
+
         weights_fp32 = weights.astype(jnp.float32)
 
         # Static token-count branch: small (decode) batches avoid the unrolled

--- a/python/sgl_jax/test/kernels/sc_moe_permute_test.py
+++ b/python/sgl_jax/test/kernels/sc_moe_permute_test.py
@@ -159,6 +159,37 @@ class EPMoEScPermuteTest(absltest.TestCase):
         self.assertLess(np.abs(a - b).max(), 2e-2 * scale)
         self.assertLess(np.abs(a - b).mean(), 5e-3 * np.abs(a).mean())
 
+    def test_small_batch_lowers_to_identical_hlo(self):
+        """Decode-sized batches must not pay for the opt-in: the SC gate is trace-time,
+        so the lowered module is byte-identical to the flag-off path."""
+        ndev = len(jax.devices())
+        mesh = create_device_mesh(ici_parallelism=[1, ndev], dcn_parallelism=[1, 1])
+        hidden, inter, num_experts, topk, T = 1024, 512, 4 * ndev, 4, 32
+        topk_ids, w, *_ = _routing(T, num_experts, topk, seed=5)
+        with jax.set_mesh(mesh):
+            common = dict(
+                hidden_size=hidden,
+                num_experts=num_experts,
+                num_experts_per_tok=topk,
+                ep_size=ndev,
+                mesh=mesh,
+                intermediate_dim=inter,
+            )
+            layer_xla = EPMoE(use_sc_permute=False, **common)
+            layer_sc = EPMoE(use_sc_permute=True, **common)
+            for name in ("wi_0", "wi_1", "wo"):
+                getattr(layer_sc, name).value = getattr(layer_xla, name).value
+            sh = jax.sharding.NamedSharding(mesh, P(None, None))
+            hs = jax.device_put(jnp.zeros((T, hidden), jnp.bfloat16), sh)
+            tw = jax.device_put(jnp.asarray(w), sh)
+            ti = jax.device_put(jnp.asarray(topk_ids.astype(np.int32)), sh)
+            texts = []
+            for layer in (layer_xla, layer_sc):
+                fn = jax.jit(lambda h, tw_, ti_, layer_=layer: layer_(h, tw_, ti_))
+                texts.append(fn.lower(hs, tw, ti).as_text())
+        self.assertEqual(texts[0], texts[1])
+        self.assertNotIn("sc_ragged_gather", texts[1])
+
     def test_env_flag_default_off(self):
         ndev = len(jax.devices())
         mesh = create_device_mesh(ici_parallelism=[1, ndev], dcn_parallelism=[1, 1])

--- a/python/sgl_jax/test/kernels/sc_moe_permute_test.py
+++ b/python/sgl_jax/test/kernels/sc_moe_permute_test.py
@@ -1,0 +1,179 @@
+"""Tests for the SparseCore MoE permute/unpermute kernels (TPU with SparseCore only)."""
+
+import os
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from absl.testing import absltest, parameterized
+from jax.sharding import PartitionSpec as P
+
+from sgl_jax.srt.kernels.sparse_core.moe_permute import (
+    reference_combine,
+    sc_combine,
+    sc_dispatch_gather,
+    sparse_core_available,
+)
+from sgl_jax.srt.layers.moe import EPMoE
+from sgl_jax.test.test_utils import create_device_mesh
+
+jax.config.parse_flags_with_absl()
+
+HIDDEN = 6144
+NUM_EXPERTS = 256
+LOCAL_EXPERTS = 16
+TOPK = 8
+
+
+def _routing(T, num_experts, topk, seed):
+    rng = np.random.default_rng(seed)
+    logits = rng.standard_normal((T, num_experts)).astype(np.float32)
+    topk_ids = np.argsort(-logits, axis=1)[:, :topk]
+    w = np.take_along_axis(logits, topk_ids, 1)
+    w = np.exp(w)
+    w /= w.sum(1, keepdims=True)
+    flat = topk_ids.ravel()
+    sorted_sel = np.argsort(flat, kind="stable")
+    revert = np.empty_like(sorted_sel)
+    revert[sorted_sel] = np.arange(sorted_sel.size)
+    group_sizes = np.bincount(flat, minlength=num_experts)
+    return topk_ids, w.astype(np.float32), sorted_sel, revert, group_sizes
+
+
+def _cos(a, b):
+    a = np.asarray(a, np.float64).ravel()
+    b = np.asarray(b, np.float64).ravel()
+    return float(a @ b / (np.linalg.norm(a) * np.linalg.norm(b) + 1e-30))
+
+
+class ScMoePermuteKernelTest(parameterized.TestCase):
+    def setUp(self):
+        super().setUp()
+        if not sparse_core_available():
+            self.skipTest("requires a TPU with SparseCore")
+
+    @parameterized.parameters(64, 1024, 4096, 8192)
+    def test_dispatch_gather_matches_xla_on_local_rows(self, T):
+        rng = np.random.default_rng(1)
+        topk_ids, _, sorted_sel, _, group_sizes = _routing(T, NUM_EXPERTS, TOPK, seed=T)
+        token_indices = (sorted_sel // TOPK).astype(np.int32)
+        # local shard = experts [LOCAL_EXPERTS, 2*LOCAL_EXPERTS): a non-zero offset exercises `start`.
+        offsets = np.concatenate([[0], np.cumsum(group_sizes)])
+        start, end = int(offsets[LOCAL_EXPERTS]), int(offsets[2 * LOCAL_EXPERTS])
+        hidden = jnp.asarray(rng.standard_normal((T, HIDDEN)).astype(np.float32)).astype(
+            jnp.bfloat16
+        )
+        tok = jnp.asarray(token_indices)
+        ref = hidden[tok]
+        out = sc_dispatch_gather(
+            hidden, tok, jnp.asarray(start, jnp.int32), jnp.asarray(end, jnp.int32)
+        )
+        self.assertEqual(out.shape, ref.shape)
+        self.assertEqual(out.dtype, ref.dtype)
+        np.testing.assert_array_equal(
+            np.asarray(out[start:end].astype(jnp.float32)),
+            np.asarray(ref[start:end].astype(jnp.float32)),
+        )
+
+    @parameterized.product(T=(64, 1024, 4096, 8192), weight_dtype=(jnp.float32, jnp.bfloat16))
+    def test_combine_matches_reference_and_masks_nonlocal_rows(self, T, weight_dtype):
+        rng = np.random.default_rng(2)
+        topk_ids, w, sorted_sel, revert, group_sizes = _routing(T, NUM_EXPERTS, TOPK, seed=T + 7)
+        flat = topk_ids.ravel()
+        local = (flat >= LOCAL_EXPERTS) & (flat < 2 * LOCAL_EXPERTS)
+        offsets = np.concatenate([[0], np.cumsum(group_sizes)])
+        start, end = int(offsets[LOCAL_EXPERTS]), int(offsets[2 * LOCAL_EXPERTS])
+        # gmm output sorted by expert. Production zero-fills non-local rows; here we
+        # deliberately put garbage there so the test proves the mask is honoured.
+        x = rng.standard_normal((T * TOPK, HIDDEN)).astype(np.float32) * 1e3
+        x[start:end] = rng.standard_normal((end - start, HIDDEN)).astype(np.float32)
+        x = jnp.asarray(x).astype(jnp.bfloat16)
+        x_clean = x.at[:start].set(0).at[end:].set(0)
+        weights = jnp.asarray(w).astype(weight_dtype)
+        revert_j = jnp.asarray(revert.astype(np.int32))
+        mask = jnp.asarray(local)
+
+        ref = reference_combine(x_clean, revert_j, weights, TOPK)
+        out = sc_combine(x, revert_j, weights, mask, TOPK)
+        self.assertEqual(out.shape, (T, HIDDEN))
+        self.assertEqual(out.dtype, jnp.bfloat16)
+        ref32 = np.asarray(ref.astype(jnp.float32))
+        out32 = np.asarray(out.astype(jnp.float32))
+        self.assertGreater(_cos(ref32, out32), 0.9999)
+        np.testing.assert_allclose(out32, ref32, rtol=2e-2, atol=2e-2)
+
+
+class EPMoEScPermuteTest(absltest.TestCase):
+    """Whole-layer parity: EPMoE with the SparseCore permute path vs the XLA path."""
+
+    def setUp(self):
+        super().setUp()
+        if not sparse_core_available():
+            self.skipTest("requires a TPU with SparseCore")
+
+    def test_epmoe_output_parity(self):
+        ndev = len(jax.devices())
+        mesh = create_device_mesh(ici_parallelism=[1, ndev], dcn_parallelism=[1, 1])
+        hidden, inter, num_experts, topk, T = 1024, 512, 4 * ndev, 4, 8192
+        rng = np.random.default_rng(3)
+        topk_ids, w, *_ = _routing(T, num_experts, topk, seed=11)
+
+        with jax.set_mesh(mesh):
+            common = dict(
+                hidden_size=hidden,
+                num_experts=num_experts,
+                num_experts_per_tok=topk,
+                ep_size=ndev,
+                mesh=mesh,
+                intermediate_dim=inter,
+            )
+            layer_xla = EPMoE(use_sc_permute=False, **common)
+            layer_sc = EPMoE(use_sc_permute=True, **common)
+            for name in ("wi_0", "wi_1", "wo"):
+                getattr(layer_sc, name).value = getattr(layer_xla, name).value
+            hs = jax.device_put(
+                jnp.asarray(rng.standard_normal((T, hidden)).astype(np.float32)).astype(
+                    jnp.bfloat16
+                ),
+                jax.sharding.NamedSharding(mesh, P(None, None)),
+            )
+            tw = jax.device_put(jnp.asarray(w), jax.sharding.NamedSharding(mesh, P(None, None)))
+            ti = jax.device_put(
+                jnp.asarray(topk_ids.astype(np.int32)),
+                jax.sharding.NamedSharding(mesh, P(None, None)),
+            )
+            self.assertTrue(layer_sc.use_sc_permute)
+            self.assertFalse(layer_xla.use_sc_permute)
+            out_xla = layer_xla(hs, tw, ti)
+            out_sc = layer_sc(hs, tw, ti)
+
+        a = np.asarray(out_xla.astype(jnp.float32))
+        b = np.asarray(out_sc.astype(jnp.float32))
+        self.assertEqual(a.shape, b.shape)
+        # Outputs are O(1e4..1e5) with heavy cancellation across top_k terms, so
+        # per-element rtol is meaningless; bound the error relative to the output
+        # scale instead. (A float64 emulation puts the SC path *closer* to exact
+        # than the XLA einsum, see ~/GLM/sc-moe-permute/parity_probe.log.)
+        scale = np.abs(a).max()
+        self.assertGreater(_cos(a, b), 0.9999)
+        self.assertLess(np.abs(a - b).max(), 2e-2 * scale)
+        self.assertLess(np.abs(a - b).mean(), 5e-3 * np.abs(a).mean())
+
+    def test_env_flag_default_off(self):
+        ndev = len(jax.devices())
+        mesh = create_device_mesh(ici_parallelism=[1, ndev], dcn_parallelism=[1, 1])
+        with jax.set_mesh(mesh):
+            layer = EPMoE(
+                hidden_size=256,
+                num_experts=ndev,
+                num_experts_per_tok=1,
+                ep_size=ndev,
+                mesh=mesh,
+                intermediate_dim=128,
+            )
+        self.assertFalse(layer.use_sc_permute)
+        self.assertNotIn("SGL_JAX_MOE_SC_PERMUTE", os.environ)
+
+
+if __name__ == "__main__":
+    absltest.main()


### PR DESCRIPTION
## Summary

Vendors tpu-inference's SparseCore `ragged_gather_v2` / `ragged_gather_reduce_v2` kernels (Apache-2.0) under `sgl_jax/srt/kernels/sparse_core/` and wires them into `EPMoE` behind an opt-in:

- `SGL_JAX_MOE_SC_PERMUTE=1` (or `EPMoE(use_sc_permute=True)`), default **off**.
- dispatch: `inputs_2d[token_indices]` -> `ragged_gather_v2` gathering only this expert shard's sorted-row range.
- combine: the SC path replaces the unpermute gather + weighted reduce with `ragged_gather_reduce` (fused gather + top-k weighted reduce, fp32 accumulate, non-local rows masked), inserted ahead of the stock fp32 paths from #1578/#1631 and following the 2-D routing-weights contract from #1577.
- Trace-time gate (`should_use_sparse_core`): below tpu-inference's VMEM heuristic (decode-sized batches) the layer lowers to a module byte-identical to the flag-off build (test enforced). No SparseCore -> plain XLA path.

## Why

On v7x, XLA already offloads the EPMoE gathers to SparseCore (`gather_offload_async_*`), but it materializes every `tokens * top_k` row for all experts (805 MB per layer-chunk at chunk 8192 / hidden 6144) and the TensorCore blocks on the async-done; the combine einsum stays on the TensorCore. In a GLM-5.2 110k prefill trace the permute/unpermute glue is ~2.1 s per device (7% of device time). The ragged kernels only move the local expert rows.

## Microbench (v7x single chip, bf16, hidden 6144, top_k 8, 16/256 local experts)

| T tokens | dispatch XLA | dispatch SC | combine XLA | combine SC |
|---|---|---|---|---|
| 8192 | 0.87 ms | 0.13 ms | 1.66 ms | 0.37 ms |
| 2048 | 0.15 ms | 0.06 ms | 0.44 ms | 0.13 ms |
| 1024 | 0.18 ms | 0.06 ms | 0.23 ms | 0.10 ms |
| 64 | fallback (identical HLO) | | | |

## E2E (GLM-5.2 FP8, v7x tp16/ep16, dsa_sparse stack, jax 0.11.1)

Current main (64dd38e5 image, ctx 135168 chunk 8192, same server pair, in-place flag toggle, 3 probe rounds x 2 independent runs, zero variance):

| metric | flag off | flag on | delta |
|---|---|---|---|
| TTFT 110k | 22.27 s (reproduces the pure-main anchor) | 21.07 s | -5.4% |
| TTFT 16k | 2.42 s | 2.25 s | -7.0% |
| decode TPOT cc=1/8/32 (1024/256) | 13.70 / 35.83 / 100.0 ms (same-image pure-main reference) | 13.74 / 36.01 / 99.06 ms | neutral, throughput monotonic in concurrency |
| gsm8k 200q 5-shot temp0 (quick regression, not an accuracy claim) | 0.945-0.955 (same-image pure-main runs) | 0.965, Invalid 0 | in band |

Earlier same-pod paired suite on the pre-#1631 base (archived for reference): TTFT 110k -5.9%, 16k -7.5%, output tok/s cc=1/8/32 +2%/+4%/+4.6%, gsm8k on/off 0.965/0.960 with 191/200 predictions identical.

Numerics: whole-layer parity SC vs XLA cos > 0.9999; a float64 emulation puts the SC path closer to exact than the XLA einsum (bf16-pass f32 dot).

## Test plan

- [x] `test/kernels/sc_moe_permute_test.py` on v7x (15 tests: kernel parity incl. masking + f32/bf16 weights, EPMoE parity, small-batch HLO identity, default off)
- [x] flag-off regression: `test_moe_weight_loader_sharding.py`, `test_moe_topk.py`
- [x] e2e TTFT 16k/110k A/B on current main, off-arm reproduces the pure-main anchor first
- [x] cc=1/8/32 sanity (throughput monotonic, no point below single-stream)
- [x] gsm8k 200q in band
- [x] pre-commit clean

## Notes / limits

- Performance claims are scoped to v7x tp16; on v6e only the unit tests run (CI). tpu-inference disabled one of these kernels on v6e for accuracy (#3036), so keep the opt-in off on v6e until tested there.
- `core_map_helper` uses `jax._src` internals (same as upstream tpu-inference); validated on jax 0.11.1.
- No tuned params for (65536, 6144, 8, bf16): default heuristic; tuning table is a follow-up.
